### PR TITLE
Create Interim Steering Committee charter

### DIFF
--- a/governance/INTERIM-STEERING-COMMITTEE.md
+++ b/governance/INTERIM-STEERING-COMMITTEE.md
@@ -1,0 +1,84 @@
+# OpenXLA Interim Steering Committee
+
+The OpenXLA Interim Steering Committee (OISC) is a group of Google maintainers of OpenXLA (with representatives from IREE, StableHLO, and XLA) responsible for bootstrapping [OpenXLA project governance](https://github.com/openxla/community/blob/main/GOVERNANCE.md). Once the OISC's initial scope of work has been accomplished, and long-term governance bodies are established, this group will disband. 
+
+## Charter
+
+Quickly and transparently establish initial governance documentation, process & membership for OpenXLA. Delegate further evolution of project governance to the (to be created) OpenXLA Core Maintainers group. 
+
+**In scope:**
+
+* Establish initial community resources and processes, including RFCs, communication channels, Code of Conduct, GitHub org policy.
+* Establish initial criteria/requirements for membership in OpenXLA & maintainer groups. 
+* Bootstrap Core Maintainers and Module Maintainers groups, including initial charter & membership. 
+* Identify/recommend other needed governance bodies (eg for GitHub Org management & policy).
+* Handle any project escalations before Core Maintainers groups are established. 
+
+**Out of scope:**
+
+* Creating contributor guidelines for individual modules/projects
+* Approving RFCs for individual modules/projects
+* Setting repo-level policy 
+
+## How we work 
+
+The Interim Steering Committee meets regularly, and makes consensus-based decisions per [OpenXLA project governance](https://github.com/openxla/community/blob/main/GOVERNANCE.md).  Work is tracked in PRs and Issues on the [openxla/community](https://github.com/openxla/community/tree/main/meetings) repo, and the OISC invites your feedback there.
+
+## Committee Members
+
+Committee members are Googlers who contribute to and maintain OpenXLA project repos.
+
+<table>
+  <tr>
+   <td><strong>Member </strong>
+   </td>
+   <td><strong>Profile</strong>
+   </td>
+  </tr>
+  <tr>
+   <td>Eugene Burmako
+   </td>
+   <td>burmako
+   </td>
+  </tr>
+  <tr>
+   <td>Geoffrey Martin-Noble
+   </td>
+   <td>gmngeoffrey
+   </td>
+  </tr>
+  <tr>
+   <td>Jacques Pienaar
+   </td>
+   <td>jpienaar
+   </td>
+  </tr>
+  <tr>
+   <td>Stella Laurenzo
+   </td>
+   <td>stellaraccident
+   </td>
+  </tr>
+  <tr>
+   <td>Stephan Herhut
+   </td>
+   <td>sherhut
+   </td>
+  </tr>
+  <tr>
+   <td>Thea Lamkin
+   </td>
+   <td>theadactyl
+   </td>
+  </tr>
+</table>
+
+
+## Getting in touch
+
+There are two ways to raise issues to the Interim Steering Committee:
+
+
+
+1. Emailing the steering committee at [openxla-interim-steering@openxla.org](mailto:openxla-interim-steering@openxla.org). This is a private discussion list to which all members of the committee have access.
+2. Open an issue in the [openxla/community](https://github.com/openxla/community/tree/main/meetings) repo and indicate that you would like attention from the steering committee. 


### PR DESCRIPTION
Creating the OpenXLA Steering Committee, a _temporary_ group to bootstrap OpenXLA governance as defined [here](https://github.com/openxla/community/blob/main/governance/GOVERNANCE.md). 