### PR TITLE
Enable Google Analytics

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -46,3 +46,10 @@ To learn more about publishing with mkdocs, see the following resources:
 
 * [Deploying your docs](https://www.mkdocs.org/user-guide/deploying-your-docs/)
 * [Publishing your site](https://squidfunk.github.io/mkdocs-material/publishing-your-site/)
+
+## Analytics
+
+The website supports Google Analytics 4. To learn more, see
+[Setting up site analytics](https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-analytics/)
+and
+[Ensuring data privacy](https://squidfunk.github.io/mkdocs-material/setup/ensuring-data-privacy/).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,9 @@ extra:
     - icon: fontawesome/solid/users
       link: https://github.com/openxla/community#welcome-to-the-openxla-community
       name: OpenXLA community info
+  analytics:
+    provider: google
+    property: G-Z67BRKDG1B
 
 theme:
   name: material

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,17 @@ extra:
   analytics:
     provider: google
     property: G-Z67BRKDG1B
+  consent:
+    title: Cookie consent
+    description: >-
+      OpenXLA uses cookies from Google to deliver and enhance the quality of its
+      services and to analyze traffic. Material for MkDocs requires consent to
+      fetch statistics about OpenXLA on GitHub.
+    actions:
+      - accept
+      - manage
+    cookies:
+      analytics: Google Analytics
 
 theme:
   name: material
@@ -44,3 +55,6 @@ markdown_extensions:
       check_paths: True     #   and fail the build if file not found
 
 plugins: [] # Empty plugins list merely to disable search
+copyright: >
+  Copyright &copy; 2023 OpenXLA.
+  <a href="#__consent">Change cookie settings</a>.


### PR DESCRIPTION
This commit enables Google Analytics 4, following [these instructions](https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-analytics/). 

If you inspect the generated HTML, you should find something like this in the head of each page:

```html
<script id="__analytics">function __md_analytics(){function n(){dataLayer.push(arguments)}window.dataLayer=window.dataLayer||[],n("js",new Date),n("config","G-Z67BRKDG1B"),document.addEventListener("DOMContentLoaded",function(){document.forms.search&&document.forms.search.query.addEventListener("blur",function(){this.value&&n("event","search",{search_term:this.value})}),document$.subscribe(function(){var a=document.forms.feedback;if(void 0!==a)for(var e of a.querySelectorAll("[type=submit]"))e.addEventListener("click",function(e){e.preventDefault();var t=document.location.pathname,e=this.getAttribute("data-md-value");n("event","feedback",{page:t,data:e}),a.firstElementChild.disabled=!0;e=a.querySelector(".md-feedback__note [data-md-value='"+e+"']");e&&(e.hidden=!1)}),a.hidden=!1}),location$.subscribe(function(e){n("config","G-Z67BRKDG1B",{page_path:e.pathname})})});var e=document.createElement("script");e.async=!0,e.src="https://www.googletagmanager.com/gtag/js?id=G-Z67BRKDG1B",document.getElementById("__analytics").insertAdjacentElement("afterEnd",e)}</script>
```

It's also possible to ask for cookie consent, as described at [Ensuring data privacy](https://squidfunk.github.io/mkdocs-material/setup/ensuring-data-privacy/). I'm not sure if we need to enable this, but I'll follow up. **NOTE:** Ad blockers seem to prevent the cookie consent, so if we do enable this, we need to test in a browser without ad blocking.