### PR TITLE
Update Zoom link to Google Meet link

### DIFF
--- a/meetings/OPENXLA_MEETINGS_GUIDE.md
+++ b/meetings/OPENXLA_MEETINGS_GUIDE.md
@@ -4,7 +4,7 @@
 
   * Cadence: Every third Tuesday of the month
   * Time: 8-9 AM PDT (3-4 PM UTC)
-  * Location: [Zoom](https://us02web.zoom.us/j/87557882524?pwd=QUJZQlZub0tRTk1CbCt4eFYzZ0lJUT09)
+  * Location: [Google Meet](http://meet.google.com/epx-gfvk-mud)
 
 ## Before Meeting: 
 


### PR DESCRIPTION
Per last months [agenda notes](https://groups.google.com/a/openxla.org/g/openxla-discuss/c/Pe1QW1nfO00/m/9qm1_6EWAwAJ) I believe this meeting is moving to meet. Please double-check the URL, I took this from [bit.ly/openxla-community-notes](https://bit.ly/openxla-community-notes). 