### PR TITLE
[RFC] Establish OpenXLA Code of Conduct

### DIFF
--- a/rfcs/20230929-code-of-conduct.md
+++ b/rfcs/20230929-code-of-conduct.md
@@ -1,0 +1,100 @@
+# RFC - Establishing OpenXLA Code of Conduct
+
+We would like to establish a code of conduct for the OpenXLA community. In this
+initial RFC, we will focus on the code of conduct itself and leave the
+definition of enforcement measures to a follow-on rfc.
+
+Currently, core maintainers also serve as the point of contact for code of
+conduct violations. We decided for this approach to reduce the number of
+committees we need to create and maintain. Should the need arise, we can
+transition to a dedicated code of conduct committee.
+
+Below is the text of the propose code of conduct.
+
+# OpenXLA Code of Conduct
+
+## Our pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Conflict Resolution
+
+We do not believe that all conflict is bad; healthy debate and disagreement
+often yield positive results. However, it is never okay to be disrespectful or
+to engage in behavior that violates the project’s code of conduct.  If you see
+someone violating the code of conduct, you are encouraged to address the
+behavior directly with those involved. Many issues can be resolved quickly and
+easily, and this gives people more control over the outcome of their dispute. If
+you are unable to resolve the matter for any reason, or if the behavior is
+threatening or harassing, report it. We are dedicated to providing an
+environment where participants feel welcome and safe.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the OpenXLA Core Maintainers committee at conduct@openxla.org.
+Alternatively, you can contact any of the individual members of the OpenXLA Core
+maintainers committee to submit your report. All complaints will be reviewed and
+investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor
+Covenant][https://www.contributor-covenant.org/], version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][https://www.contributor-covenant.org/version/2/1/code_of_conduct.html].
+


### PR DESCRIPTION
The OpenXLA project currently has no written down code of conduct. We have discussed this among core maintainers and agreed on corner stones of a code of conduct. I have assembled a proposal based on commonly used write ups that covers what we consider crucial.

Please comment or propose changes if there is an area we have not covered or that needs clarifying. Note that we will do a follow up RFC on enforcement.

